### PR TITLE
Allow to use patterns to match multiple shapes, fills and strokes instead of names

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -119,139 +119,139 @@ class _RiveChangeColorExampleAppState extends State<RiveChangeColorExampleApp> {
                   components: [
                     //* BACKGROUND COLOR
                     RiveColorComponent(
-                      shapeName: 'Background',
-                      fillName: 'Background Fill',
+                      shapePattern: 'Background',
+                      fillPattern: 'Background Fill',
                       color: isDarkMode ? vBackgroundColor : dBackgroundColor,
                     ),
                     //* SKIN COLOR
                     RiveColorComponent(
-                      shapeName: 'Head Skin',
-                      fillName: 'Head Skin Fill',
+                      shapePattern: 'Head Skin',
+                      fillPattern: 'Head Skin Fill',
                       color: isDarkMode ? vSkinColor : dSkinColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Neck Skin',
-                      fillName: 'Neck Skin Fill',
+                      shapePattern: 'Neck Skin',
+                      fillPattern: 'Neck Skin Fill',
                       color: isDarkMode ? vSkinColor : dSkinColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Left Arm Skin',
-                      strokeName: 'Left Arm Skin Stroke',
+                      shapePattern: 'Left Arm Skin',
+                      strokePattern: 'Left Arm Skin Stroke',
                       color: isDarkMode ? vSkinColor : dSkinColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Arm Skin',
-                      strokeName: 'Right Arm Skin Stroke',
+                      shapePattern: 'Right Arm Skin',
+                      strokePattern: 'Right Arm Skin Stroke',
                       color: isDarkMode ? vSkinColor : dSkinColor,
                     ),
                     //* HAIR COLOR
                     RiveColorComponent(
-                      shapeName: 'Hair',
-                      fillName: 'Hair Fill',
+                      shapePattern: 'Hair',
+                      fillPattern: 'Hair Fill',
                       color: isDarkMode ? vHairColor : dHairColor,
                     ),
                     //* BANDANA COLOR
                     RiveColorComponent(
-                      shapeName: 'Bandana',
-                      fillName: 'Bandana Fill',
+                      shapePattern: 'Bandana',
+                      fillPattern: 'Bandana Fill',
                       color: isDarkMode ? vBandanaColor : dBandanaColor,
                     ),
                     //* BANDANA LINES COLOR
                     RiveColorComponent(
-                      shapeName: 'Bandana Lines',
-                      strokeName: 'Bandana Lines Stroke',
+                      shapePattern: 'Bandana Lines',
+                      strokePattern: 'Bandana Lines Stroke',
                       color:
                           isDarkMode ? vBandanaLinesColor : dBandanaLinesColor,
                     ),
                     //* EYEBROW COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Eyebrow',
-                      strokeName: 'Left Eyebrow Stroke',
+                      shapePattern: 'Left Eyebrow',
+                      strokePattern: 'Left Eyebrow Stroke',
                       color: isDarkMode ? vEyebrowColor : dEyebrowColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Eyebrow',
-                      strokeName: 'Right Eyebrow Stroke',
+                      shapePattern: 'Right Eyebrow',
+                      strokePattern: 'Right Eyebrow Stroke',
                       color: isDarkMode ? vEyebrowColor : dEyebrowColor,
                     ),
                     //* EYE COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Pupil',
-                      fillName: 'Left Pupil Fill',
+                      shapePattern: 'Left Pupil',
+                      fillPattern: 'Left Pupil Fill',
                       color: isDarkMode ? vEyeColor : dEyeColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Pupil',
-                      fillName: 'Right Pupil Fill',
+                      shapePattern: 'Right Pupil',
+                      fillPattern: 'Right Pupil Fill',
                       color: isDarkMode ? vEyeColor : dEyeColor,
                     ),
                     //* CLOSED EYE COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Eye Closed',
-                      strokeName: 'Left Eye Closed Stroke',
+                      shapePattern: 'Left Eye Closed',
+                      strokePattern: 'Left Eye Closed Stroke',
                       color: isDarkMode ? vMouthColor : dMouthColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Eye Closed',
-                      strokeName: 'Right Eye Closed Stroke',
+                      shapePattern: 'Right Eye Closed',
+                      strokePattern: 'Right Eye Closed Stroke',
                       color: isDarkMode ? vMouthColor : dMouthColor,
                     ),
                     //* NOSE COLOR
                     RiveColorComponent(
-                      shapeName: 'Nose',
-                      fillName: 'Nose Fill',
+                      shapePattern: 'Nose',
+                      fillPattern: 'Nose Fill',
                       color: isDarkMode ? vNoseColor : dNoseColor,
                     ),
                     //* MOUTH COLOR
                     RiveColorComponent(
-                      shapeName: 'Mouth',
-                      strokeName: 'Mouth Stroke',
+                      shapePattern: 'Mouth',
+                      strokePattern: 'Mouth Stroke',
                       color: isDarkMode ? vMouthColor : dMouthColor,
                     ),
                     //* EARRING COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Earring',
-                      fillName: 'Left Earring Fill',
+                      shapePattern: 'Left Earring',
+                      fillPattern: 'Left Earring Fill',
                       color: isDarkMode ? vEarringColor : dEarringColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Earring',
-                      fillName: 'Right Earring Fill',
+                      shapePattern: 'Right Earring',
+                      fillPattern: 'Right Earring Fill',
                       color: isDarkMode ? vEarringColor : dEarringColor,
                     ),
                     //* OVERALL COLOR
                     RiveColorComponent(
-                      shapeName: 'Overall',
-                      fillName: 'Overall Fill',
+                      shapePattern: 'Overall',
+                      fillPattern: 'Overall Fill',
                       color: isDarkMode ? vOverallColor : dOverallColor,
                     ),
                     //* POCKET COLOR
                     RiveColorComponent(
-                      shapeName: 'Pocket',
-                      strokeName: 'Pocket Stroke',
+                      shapePattern: 'Pocket',
+                      strokePattern: 'Pocket Stroke',
                       color: isDarkMode ? vPocketColor : dPocketColor,
                     ),
                     //* BUTTON COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Button',
-                      fillName: 'Left Button Fill',
+                      shapePattern: 'Left Button',
+                      fillPattern: 'Left Button Fill',
                       color: isDarkMode ? vButtonColor : dButtonColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Button',
-                      fillName: 'Right Button Fill',
+                      shapePattern: 'Right Button',
+                      fillPattern: 'Right Button Fill',
                       color: isDarkMode ? vButtonColor : dButtonColor,
                     ),
                     //* BUTTON THREAD COLOR
                     RiveColorComponent(
-                      shapeName: 'Left Button Thread',
-                      strokeName: 'Left Button Thread Stroke',
+                      shapePattern: 'Left Button Thread',
+                      strokePattern: 'Left Button Thread Stroke',
                       color:
                           isDarkMode ? vButtonThreadColor : dButtonThreadColor,
                     ),
                     RiveColorComponent(
-                      shapeName: 'Right Button Thread',
-                      strokeName: 'Right Button Thread Stroke',
+                      shapePattern: 'Right Button Thread',
+                      strokePattern: 'Right Button Thread Stroke',
                       color:
                           isDarkMode ? vButtonThreadColor : dButtonThreadColor,
                     ),

--- a/lib/src/rive_color_component.dart
+++ b/lib/src/rive_color_component.dart
@@ -23,8 +23,7 @@ class RiveColorComponent {
     this.fillPattern,
     this.strokePattern,
     required this.color,
-  }) : assert(fillPattern == null || strokePattern == null,
-            "Fill or stroke name must be provided, but not both");
+  });
 
   /// Overrides the equality operator for the [RiveColorComponent] class.
   ///

--- a/lib/src/rive_color_component.dart
+++ b/lib/src/rive_color_component.dart
@@ -1,30 +1,29 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:ui';
 
 import 'package:rive/rive.dart';
 
 /// Represents a color component of a Rive animation.
 class RiveColorComponent {
-  final String shapeName;
-  final String? fillName;
+  final String shapePattern;
+  final String? fillPattern;
+  final String? strokePattern;
   final Color color;
-  final String? strokeName;
 
-  Shape? shape;
-  Fill? fill;
-  Stroke? stroke;
+  List<ShapeComponents> shapeComponents = [];
 
   /// Creates a [RiveColorComponent].
   ///
-  /// The [shapeName] is the name of the shape in the Rive animation.
-  /// The [fillName] is the name of the fill in the shape. Either [fillName]
-  /// or [strokeName] must be provided, but not both.
+  /// The [shapePattern] is the name of the shape in the Rive animation.
+  /// The [fillPattern] is the name of the fill in the shape. Either [fillPattern]
+  /// or [strokePattern] must be provided, but not both.
   /// The [color] is the color to be applied to the component.
   RiveColorComponent({
-    required this.shapeName,
-    this.fillName,
-    this.strokeName,
+    required this.shapePattern,
+    this.fillPattern,
+    this.strokePattern,
     required this.color,
-  }) : assert(fillName == null || strokeName == null,
+  }) : assert(fillPattern == null || strokePattern == null,
             "Fill or stroke name must be provided, but not both");
 
   /// Overrides the equality operator for the [RiveColorComponent] class.
@@ -32,25 +31,37 @@ class RiveColorComponent {
   /// Returns `true` if the [other] object is equal to this [RiveColorComponent]
   /// object, `false` otherwise.
   ///
-  /// Two [RiveColorComponent] objects are considered equal if their [fillName],
-  ///  [shapeName], [strokeName], and [color] properties are all equal.
+  /// Two [RiveColorComponent] objects are considered equal if their [fillPattern],
+  ///  [shapePattern], [strokePattern], and [color] properties are all equal.
   @override
   bool operator ==(covariant RiveColorComponent other) {
     if (identical(this, other)) return true;
 
-    return other.fillName == fillName &&
-        other.shapeName == shapeName &&
-        other.strokeName == strokeName &&
+    return other.fillPattern == fillPattern &&
+        other.shapePattern == shapePattern &&
+        other.strokePattern == strokePattern &&
         other.color == color;
   }
 
   /// Overrides the default hashCode getter to calculate the hash code based
-  /// on the values of [fillName], [shapeName], [strokeName], and [color].
+  /// on the values of [fillPattern], [shapePattern], [strokePattern], and [color].
   @override
   int get hashCode {
-    return fillName.hashCode ^
-        shapeName.hashCode ^
-        strokeName.hashCode ^
+    return fillPattern.hashCode ^
+        shapePattern.hashCode ^
+        strokePattern.hashCode ^
         color.hashCode;
   }
+}
+
+class ShapeComponents {
+  ShapeComponents({
+    required this.shape,
+    required this.fill,
+    required this.stroke,
+  });
+
+  final Shape shape;
+  final List<Fill> fill;
+  final List<Stroke> stroke;
 }

--- a/lib/src/rive_custom_render_object.dart
+++ b/lib/src/rive_custom_render_object.dart
@@ -27,9 +27,13 @@ class RiveCustomRenderObject extends RiveRenderObject {
 
     for (final component in _components) {
       final shapePatternRegExp = RegExp(component.shapePattern);
-      final shapes = artboard.objects.where(
-        (object) => object is Shape && shapePatternRegExp.hasMatch(object.name),
-      ) as List<Shape>;
+      final shapes = artboard.objects
+          .where(
+            (object) =>
+                object is Shape && shapePatternRegExp.hasMatch(object.name),
+          )
+          .map((object) => object as Shape)
+          .toList();
 
       if (shapes.isEmpty) {
         throw Exception(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ repository: https://github.com/JSimonDev/rive_color_modifier
 issue_tracker: https://github.com/JSimonDev/rive_color_modifier/issues
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  rive: ^0.12.4
+  rive: ">=0.12.4"
 
 dev_dependencies:
   flutter_lints: ^3.0.1
@@ -22,5 +22,5 @@ dev_dependencies:
     sdk: flutter
 
 screenshots:
-  - description: 'Rive_color_modifier_preview'
+  - description: "Rive_color_modifier_preview"
     path: screenshots/rive_color_modifier_poster.png

--- a/test/rive_color_modifier_test.dart
+++ b/test/rive_color_modifier_test.dart
@@ -8,29 +8,29 @@ void main() {
     test('RiveColorComponent creation test', () {
       const color = Color(0xFFFFFFFF);
       var component = RiveColorComponent(
-        shapeName: 'shape',
-        fillName: 'fill',
+        shapePattern: 'shape',
+        fillPattern: 'fill',
         color: color,
       );
 
-      expect(component.shapeName, 'shape');
-      expect(component.fillName, 'fill');
+      expect(component.shapePattern, 'shape');
+      expect(component.fillPattern, 'fill');
       expect(component.color, color);
-      expect(component.strokeName, null);
+      expect(component.strokePattern, null);
     });
 
     test('RiveColorComponent creation with strokeName test', () {
       const color = Color(0xFFFFFFFF);
       var component = RiveColorComponent(
-        shapeName: 'shape',
-        strokeName: 'stroke',
+        shapePattern: 'shape',
+        strokePattern: 'stroke',
         color: color,
       );
 
-      expect(component.shapeName, 'shape');
-      expect(component.strokeName, 'stroke');
+      expect(component.shapePattern, 'shape');
+      expect(component.strokePattern, 'stroke');
       expect(component.color, color);
-      expect(component.fillName, null);
+      expect(component.fillPattern, null);
     });
 
     test(
@@ -39,9 +39,9 @@ void main() {
       const color = Color(0xFFFFFFFF);
       expect(
           () => RiveColorComponent(
-                shapeName: 'shape',
-                fillName: 'fill',
-                strokeName: 'stroke',
+                shapePattern: 'shape',
+                fillPattern: 'fill',
+                strokePattern: 'stroke',
                 color: color,
               ),
           throwsA(isA<AssertionError>()));
@@ -50,14 +50,14 @@ void main() {
     test('RiveColorComponent equality test', () {
       const color = Color(0xFFFFFFFF);
       var component1 = RiveColorComponent(
-        shapeName: 'shape',
-        fillName: 'fill',
+        shapePattern: 'shape',
+        fillPattern: 'fill',
         color: color,
       );
 
       var component2 = RiveColorComponent(
-        shapeName: 'shape',
-        fillName: 'fill',
+        shapePattern: 'shape',
+        fillPattern: 'fill',
         color: color,
       );
 


### PR DESCRIPTION
Using this approach you can set the colors using minimal ColorComponents. This is a breaking change.

Example:
```dart
 RiveColorComponent(
     shapePattern: '.*',
     fillPattern: '.*primary',
     strokePattern: '.*primary',
     color: primaryColor,
  ),
```

Then this component will match every fill or stroke that ends with "primary" in their names.

Now on Rive the designers only have to complain with the naming pattern 👍🏼 